### PR TITLE
Support native Windows hosts

### DIFF
--- a/path.lua
+++ b/path.lua
@@ -2,6 +2,8 @@ local String = require ('map.string')
 
 local Path = {}
 
+Path.separator = package.config:sub (1, 1)
+
 -- Returns a path (`string`) where all provided `string` arguments have been
 -- joined together. All other arguments types are ignored.
 function Path.join (...)
@@ -13,7 +15,7 @@ function Path.join (...)
 		end
 	end
 
-	return table.concat (elements, '/')
+	return table.concat (elements, Path.separator)
 end
 
 -- Returns a `boolean` indicating whether or not the specified `path (string)`

--- a/tools/grimex.lua
+++ b/tools/grimex.lua
@@ -48,7 +48,7 @@ end
 -- Returns the status of the command, as either `true (boolean)` or `nil`,
 -- along with the `output (string)`.
 local function grimex_command (prefix, executable, map, ...)
-	local output_log_path = os.tmpname ()
+	local output_log_path = '.' .. os.tmpname ()
 
 	-- Need to capture both 'stdout' and `stderr'.
 	local status = Shell.execute {

--- a/tools/pjass.lua
+++ b/tools/pjass.lua
@@ -12,7 +12,7 @@ PJass.executable = Path.join ('map', 'external', 'pjass', 'pjass.exe')
 -- Returns the status of the command, as either `true (boolean)` or `nil`,
 -- along with the `output (string)`.
 function PJass.check (prefix, options, ...)
-	local output_log_path = os.tmpname ()
+	local output_log_path = '.' .. os.tmpname ()
 
 	-- The pjass command outputs to `stdout` regardless of its exit status.
 	local status = Shell.execute {

--- a/wts.lua
+++ b/wts.lua
@@ -83,7 +83,7 @@ end
 -- Takes the provided `strings (table)` and updates the trigger string data
 -- for the specified `map (string)`. Returns `nil` if an error is encountered.
 function WTS.write (map, strings, prefix)
-	local file_path = os.tmpname ()
+	local file_path = '.' .. os.tmpname ()
 	local file = io.open (file_path, 'wb')
 
 	local status


### PR DESCRIPTION
Two problems here.

1. `/` does not always work as a path separator. Windows complains it cannot execute `map` because it does not consider the forward slashes in e.g. `map/external/pjass/pjass.exe`.

    The solution was to use the native path separator in `Path.join`. Annoyingly enough, we cannot simply replace every forward slash with a backward slash throughout the program, as the native Lua functions (e.g. `loadfile`) still require forward slashes.

2. `os.tmpname` returns root paths on Windows, e.g. `\safo.`. Accessing these files will yield a permissions error on most systems.

    The solution was to use relative paths. This will work for building Gem TD because it already has a local `tmp` directory in its repo. Thus, `\safo.` becomes `.\safo.` and `/tmp/lua_6sm2y4` becomes `./tmp/lua_6sm2y4`.

Neither of these solutions are super robust, but I hope they can save you some work.

The uninformative error message from Windows: `Access is denied.`.
My system: Windows 10 (pre-Creators update), LuaJIT 2.0.4.